### PR TITLE
Add empty message to proto definition

### DIFF
--- a/samples/grpc-app/src/main/proto/image-recognizer.proto
+++ b/samples/grpc-app/src/main/proto/image-recognizer.proto
@@ -6,8 +6,32 @@ message Image {
 
 message RecogniseResult {
   int32 category = 1;
+  Action action = 2;
 }
 
 service ImageRecognizer {
   rpc recognize(Image) returns (RecogniseResult);
 }
+
+// An action to perform when the user interacts with an item.
+message Action {
+  // The type of the action
+  oneof type {
+    PresentAction present_screen = 1;
+    DismissAction dismiss_alert = 2;
+  }
+}
+
+message PresentAction {
+  PresentationStyle presentation_style = 1;
+  string link = 2;
+
+  // The style to present the screen in
+  enum PresentationStyle {
+    MODAL = 0;
+    PUSH = 1;
+    REPLACE = 2;
+  }
+}
+
+message DismissAction {}


### PR DESCRIPTION
This change breaks the generated code in the `toPlatform` and `toKotlin` generated functions.

Input in proto:
`message DismissAction {}`

Generated code:
``` kotlin
fun DismissAction.toPlatform(): ImageRecognizerOuterClass.DismissAction {
    return ImageRecognizerOuterClass.DismissAction.newBuilder().apply
}

fun ImageRecognizerOuterClass.DismissAction.toKotlin(): DismissAction {
    return DismissAction
}
```
This code fails to compile.


The following modification on the generated code does compile:
``` kotlin
fun DismissAction.toPlatform(): ImageRecognizerOuterClass.DismissAction {
    return ImageRecognizerOuterClass.DismissAction.newBuilder().build()
}

fun ImageRecognizerOuterClass.DismissAction.toKotlin(): DismissAction {
    return DismissAction {}
}
```